### PR TITLE
Nerf thirst and hunger

### DIFF
--- a/Content.Shared/Nutrition/Components/HungerComponent.cs
+++ b/Content.Shared/Nutrition/Components/HungerComponent.cs
@@ -34,7 +34,7 @@ public sealed partial class HungerComponent : Component
     /// </summary>
     /// <remarks>Any time this is modified, <see cref="HungerSystem.SetAuthoritativeHungerValue"/> should be called.</remarks>
     [DataField("baseDecayRate"), ViewVariables(VVAccess.ReadWrite)]
-    public float BaseDecayRate = 0.01666666666f;
+    public float BaseDecayRate = 0.01f; // collard-HungerNerf
 
     /// <summary>
     /// The actual amount at which <see cref="LastAuthoritativeHungerValue"/> decays.
@@ -109,7 +109,7 @@ public sealed partial class HungerComponent : Component
     /// </summary>
     [DataField("starvingSlowdownModifier"), ViewVariables(VVAccess.ReadWrite)]
     [AutoNetworkedField]
-    public float StarvingSlowdownModifier = 0.75f;
+    public float StarvingSlowdownModifier = 0.9f; // collard-HungerNerf
 
     /// <summary>
     /// Damage dealt when your current threshold is at HungerThreshold.Dead

--- a/Content.Shared/Nutrition/Components/ThirstComponent.cs
+++ b/Content.Shared/Nutrition/Components/ThirstComponent.cs
@@ -14,7 +14,7 @@ public sealed partial class ThirstComponent : Component
     [ViewVariables(VVAccess.ReadWrite)]
     [DataField("baseDecayRate")]
     [AutoNetworkedField]
-    public float BaseDecayRate = 0.1f;
+    public float BaseDecayRate = 0.05f; // collard-ThirstNerf
 
     [ViewVariables(VVAccess.ReadWrite)]
     [AutoNetworkedField]

--- a/Content.Shared/Nutrition/EntitySystems/ThirstSystem.cs
+++ b/Content.Shared/Nutrition/EntitySystems/ThirstSystem.cs
@@ -70,7 +70,7 @@ public sealed class ThirstSystem : EntitySystem
         if (_jetpack.IsUserFlying(uid))
             return;
 
-        var mod = component.CurrentThirstThreshold <= ThirstThreshold.Parched ? 0.75f : 1.0f;
+        var mod = component.CurrentThirstThreshold <= ThirstThreshold.Parched ? 0.9f : 1.0f; // collard-ThirstNerf
         args.ModifySpeed(mod, mod);
     }
 

--- a/Resources/Prototypes/Entities/Mobs/Species/diona.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/diona.yml
@@ -8,9 +8,9 @@
   - type: HumanoidAppearance
     species: Diona
   - type: Hunger
-    baseDecayRate: 0.0083
+    baseDecayRate: 0.001 # collard-HungerNerf
   - type: Thirst
-    baseDecayRate: 0.0083
+    baseDecayRate: 0.15 # collard-ThirstNerf
   - type: Icon
     sprite: Mobs/Species/Diona/parts.rsi
     state: full


### PR DESCRIPTION
Now player mobs need to eat and drink less frequently and get less slowdown. Dionas now need to drink more and eat much less.