### PR TITLE
Prevent ghosts (aside from aghost) from editing item details.

### DIFF
--- a/Content.Server/Collard/DetailExaminable/ItemDetailSystem.cs
+++ b/Content.Server/Collard/DetailExaminable/ItemDetailSystem.cs
@@ -12,6 +12,9 @@ using Content.Server.Popups;
 using Content.Shared.Administration.Logs;
 using Content.Server.Administration.Managers;
 using Content.Shared.Database;
+using Content.Server.Ghost;
+using Content.Shared.Ghost;
+using Content.Shared.Hands.Components;
 
 namespace Content.Server.Collard.DetailExaminable
 {
@@ -59,7 +62,8 @@ namespace Content.Server.Collard.DetailExaminable
             {
                 Act = () =>
                 {
-                    _quickDialog.OpenDialog(player,
+                    if (!HasComp<GhostComponent>(args.User) || HasComp<HandsComponent>(args.User))
+                        _quickDialog.OpenDialog(player,
                                 Loc.GetString("item-detail-dialog-name"),
                                 Loc.GetString("item-detail-dialog-field"),
                                 (string newDesc) =>


### PR DESCRIPTION
Prevents ghosts without ghost component from editing item details.