### PR TITLE
Deshittify roundstart variation

### DIFF
--- a/Content.Server/GameTicking/Rules/VariationPass/Components/PoweredLightVariationPassComponent.cs
+++ b/Content.Server/GameTicking/Rules/VariationPass/Components/PoweredLightVariationPassComponent.cs
@@ -13,16 +13,16 @@ public sealed partial class PoweredLightVariationPassComponent : Component
     ///     Chance that a light will be replaced with a broken variant.
     /// </summary>
     [DataField]
-    public float LightBreakChance = 0.15f;
+    public float LightBreakChance = 0.05f; // collard-VariationDeshittification
 
     /// <summary>
     ///     Chance that a light will be replaced with an aged variant.
     /// </summary>
     [DataField]
-    public float LightAgingChance = 0.05f;
+    public float LightAgingChance = 0.03f; // collard-VariationDeshittification
 
     [DataField]
-    public float AgedLightTubeFlickerChance = 0.03f;
+    public float AgedLightTubeFlickerChance = 0.01f;  // collard-VariationDeshittification
 
     [DataField]
     public EntProtoId BrokenLightBulbPrototype = "LightBulbBroken";

--- a/Resources/Prototypes/GameRules/roundstart.yml
+++ b/Resources/Prototypes/GameRules/roundstart.yml
@@ -450,7 +450,7 @@
     - id: SolarPanelDamageVariationPass
     - id: SolarPanelEmptyVariationPass
     - id: BasicDecalDirtVariationPass
-    - id: BasicDecalGraffitiVariationPass
+    # - id: BasicDecalGraffitiVariationPass | collard-VariationDeshittification
     - id: BasicDecalBrunsVariationPass
       prob: 0.50
       orGroup: monospaceDecals


### PR DESCRIPTION
Removed random graffiti decals on round start

Decreased broken lights chances:
Broken: 15% -> 5%
Aging: 5% -> 3%
Flicker: 3% -> 1%