### PR TITLE
Make ATS distant from station

### DIFF
--- a/Resources/Prototypes/Entities/Stations/base.yml
+++ b/Resources/Prototypes/Entities/Stations/base.yml
@@ -59,6 +59,8 @@
             - type: TradeStation
           paths:
             - /Maps/Shuttles/trading_outpost.yml
+          minimumDistance: 1000 # collard-DistantATS
+          maximumDistance: 5000 # collard-DistantATS
         # Spawn last
         ruins: !type:GridSpawnGroup
           hide: true


### PR DESCRIPTION
ATS now spawns in range of 1000-5000 tiles from station